### PR TITLE
Allow force version type per flush

### DIFF
--- a/Lib/Search/ElasticSearch/Client.php
+++ b/Lib/Search/ElasticSearch/Client.php
@@ -65,14 +65,13 @@ class Client implements SearchClientInterface
      * If set to true, use versionType 'force' to allow documents with a lower es_version to overwrite documents with a higher es_version
      * @var bool
      */
-    private $forceVersion;
+    private $forceVersion = false;
 
     /**
      * @param ElasticaClient $client
      */
     public function __construct(ElasticaClient $client)
     {
-        $this->forceVersion = false;
         $this->client = $client;
     }
 

--- a/Lib/Search/ElasticSearch/Client.php
+++ b/Lib/Search/ElasticSearch/Client.php
@@ -62,10 +62,17 @@ class Client implements SearchClientInterface
     private $client;
 
     /**
+     * If set to true, use versionType 'force' to allow documents with a lower es_version to overwrite documents with a higher es_version
+     * @var bool
+     */
+    private $forceVersion;
+
+    /**
      * @param ElasticaClient $client
      */
     public function __construct(ElasticaClient $client)
     {
+        $this->forceVersion = false;
         $this->client = $client;
     }
 
@@ -110,7 +117,11 @@ class Client implements SearchClientInterface
                 if (empty($version)) {
                     throw new InvalidArgumentException('Document (index: ' . $elasticaDoc->getIndex() . ' type: ' . $elasticaDoc->getType() . ' id: ' . $document['id'] . ') misses the value for the version');
                 }
-                $elasticaDoc->setVersionType($class->getVersionType());
+                if ($this->getForceVersion() == true) {
+                    $elasticaDoc->setVersionType('force');
+                } else {
+                    $elasticaDoc->setVersionType($class->getVersionType());
+                }
                 $elasticaDoc->setVersion($version);
             }
             $documentsByIndex[$class->getIndexForWrite($document)][] = $elasticaDoc;
@@ -797,5 +808,21 @@ class Client implements SearchClientInterface
             return false;
         }
         return 200 == $response->getStatus();
+    }
+
+    /**
+     * @return bool
+     */
+    public function getForceVersion()
+    {
+        return $this->forceVersion;
+    }
+
+    /**
+     * @param bool $forceVersion
+     */
+    public function setForceVersion($forceVersion)
+    {
+        $this->forceVersion = $forceVersion;
     }
 }

--- a/Lib/Search/SearchClientInterface.php
+++ b/Lib/Search/SearchClientInterface.php
@@ -211,4 +211,18 @@ interface SearchClientInterface
      * @return boolean
      */
     public function deleteTemplate(ClassMetadata $class);
+
+    /**
+     * Set the search client to force accepting documents with a lower version
+     *
+     * @param bool $forceVersion
+     */
+    public function setForceVersion($forceVersion);
+
+    /**
+     * Set the search client to force accepting documents with a lower version
+     *
+     * @return bool
+     */
+    public function getForceVersion();
 }

--- a/Lib/Search/SearchManager.php
+++ b/Lib/Search/SearchManager.php
@@ -278,12 +278,15 @@ class SearchManager implements ObjectManager
      *
      * @param mixed $object
      * @param bool $refresh
+     * @param bool $forceVersion
      *
      * @throws Exception\DoctrineSearchException
      */
-    public function flush($object = null, $refresh = false)
+    public function flush($object = null, $refresh = false, $forceVersion = false)
     {
+        $this->client->setForceVersion($forceVersion);
         $this->unitOfWork->commit($object, $refresh);
+        $this->client->setForceVersion(false);
     }
 
     /**

--- a/Lib/Search/SearchManager.php
+++ b/Lib/Search/SearchManager.php
@@ -284,9 +284,13 @@ class SearchManager implements ObjectManager
      */
     public function flush($object = null, $refresh = false, $forceVersion = false)
     {
-        $this->client->setForceVersion($forceVersion);
+        if ($forceVersion) {
+            $this->client->setForceVersion(true);
+        }
         $this->unitOfWork->commit($object, $refresh);
-        $this->client->setForceVersion(false);
+        if ($forceVersion) {
+            $this->client->setForceVersion(false);
+        }
     }
 
     /**


### PR DESCRIPTION
-Updated ElasticSearch\Client to allow calling code to use versionType 'force' to allow documents with a lower es_version to overwrite documents with a higher es_version
