### PR TITLE
IGEOC-995 Remove unnecessary AbstractQuery param type in deleteByScanScroll

### DIFF
--- a/Lib/Search/ElasticSearch/Client.php
+++ b/Lib/Search/ElasticSearch/Client.php
@@ -176,10 +176,10 @@ class Client implements SearchClientInterface
      * Perform a scan and scroll through the results, bulk deleting by result ids
      *
      * @param ClassMetadata $class
-     * @param AbstractQuery $scanQuery
+     * @param object        $scanQuery
      * @param string        $index
      */
-    private function deleteByScanScroll(ClassMetadata $class, AbstractQuery $scanQuery, $index) {
+    private function deleteByScanScroll(ClassMetadata $class, $scanQuery, $index) {
         $type = $this->getIndex($index)->getType($class->type);
         $query = Query::create($scanQuery);
         $results = $this->scan($query, array($class));

--- a/Test/TestCase/BaseTestCase.php
+++ b/Test/TestCase/BaseTestCase.php
@@ -36,7 +36,8 @@ class BaseTestCase extends WebTestCase
     /** @var SearchManager */
     protected static $searchManager;
 
-    const TIME_SERIES_TEST_DATE_SUFFIX = "_2016_05";
+    /** @var string */
+    protected static $timeSeriesTestDateSuffix;
 
     /**
      * Initialize function, which will only be run once
@@ -46,6 +47,7 @@ class BaseTestCase extends WebTestCase
         ini_set('error_reporting', E_ALL);
         ini_set('display_errors', '1');
         ini_set('display_startup_errors', '1');
+        self::$timeSeriesTestDateSuffix = date('\_Y\_m');
         if (!self::$initialized) {
             self::$kernel = new AppKernel('test', true);
             self::$kernel->boot();
@@ -103,7 +105,7 @@ class BaseTestCase extends WebTestCase
             $this->type = new \Elastica\Type($this->index, View::INDEX_TYPE);
         }
 
-        $this->timeSeriesIndex = new \Elastica\Index($this->elasticaClient, StatusLog::INDEX_NAME . BaseTestCase::TIME_SERIES_TEST_DATE_SUFFIX);
+        $this->timeSeriesIndex = new \Elastica\Index($this->elasticaClient, StatusLog::INDEX_NAME . self::$timeSeriesTestDateSuffix);
         if (! $this->timeSeriesIndex->exists()) {
             $this->timeSeriesIndex->create(array("index.number_of_replicas" => "0", "index.number_of_shards" => "1"));
             $this->timeSeriesType = new \Elastica\Type($this->timeSeriesIndex, StatusLog::INDEX_TYPE);

--- a/Test/TestCase/MappingManagerTest.php
+++ b/Test/TestCase/MappingManagerTest.php
@@ -38,7 +38,7 @@ class MappingManagerTest extends BaseTestCase {
     }
 
     public function testUpdateTimeSeries() {
-        $index = $this->elasticaClient->getIndex(StatusLog::INDEX_NAME . BaseTestCase::TIME_SERIES_TEST_DATE_SUFFIX);
+        $index = $this->elasticaClient->getIndex(StatusLog::INDEX_NAME . self::$timeSeriesTestDateSuffix);
         $this->assertFalse($index->exists());
 
         self::$mappingManager->update();

--- a/Test/TestCase/SearchManagerTest.php
+++ b/Test/TestCase/SearchManagerTest.php
@@ -490,7 +490,7 @@ class SearchManagerTest extends BaseTestCase
     private function getIndexNameForTimeSeriesTestDate($metadata){
         $indexName = $metadata->index;
         if (isset($metadata->timeSeriesScale)) {
-            $indexName = $metadata->index . BaseTestCase::TIME_SERIES_TEST_DATE_SUFFIX;
+            $indexName = $metadata->index . self::$timeSeriesTestDateSuffix;
         }
         return $indexName;
     }


### PR DESCRIPTION
Noticed the unit test time series was brittle, fixed that as well.
@jqin @CongZhao @skbhatt for review
